### PR TITLE
Rollback version of node to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - 10
 script: npm run build
 before_script:
   - sed -i "s/GIT_CREDENTIALS/${GIT_CREDENTIALS}/" _config.yml


### PR DESCRIPTION
Travis CI build [#26](https://travis-ci.org/syniox/hexo-blog/builds/448733052) failed because the newest version of node (currently 11.1.0) hasn't been supported by [node-sass@4.9.3](https://github.com/sass/node-sass/releases/tag/v4.9.3).

This pull request fixes that by specifying node version to 10 in `.travis.yml`.